### PR TITLE
Проектная работа №2. Применение дженериков

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,1 @@
+// dev branch for Y.Practicum

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/BaseListDiffCallback.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/BaseListDiffCallback.java
@@ -1,0 +1,18 @@
+package ru.yandex.practicum.contacts.presentation.base;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.DiffUtil;
+
+public class BaseListDiffCallback<T extends ListDiffInterface<BaseListDiffCallback>> extends DiffUtil.ItemCallback<T> {
+
+
+    @Override
+    public boolean areItemsTheSame(@NonNull T oldItem, @NonNull T newItem) {
+        return false;
+    }
+
+    @Override
+    public boolean areContentsTheSame(@NonNull T oldItem, @NonNull T newItem) {
+        return false;
+    }
+}

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/ListDiffInterface.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/base/ListDiffInterface.java
@@ -1,0 +1,8 @@
+package ru.yandex.practicum.contacts.presentation.base;
+
+public interface ListDiffInterface<T> {
+
+    boolean theSameAs(T method);
+
+    boolean equals(Object o);
+}

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/FilterContactTypeAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/FilterContactTypeAdapter.java
@@ -86,23 +86,4 @@ public class FilterContactTypeAdapter extends RecyclerView.Adapter<FilterContact
             }
         }
     }
-
-//    static class ListDiffCallback extends DiffUtil.ItemCallback<FilterContactTypeUi> {
-//
-//        @Override
-//        public boolean areItemsTheSame(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-//            return oldItem.getContactType() == newItem.getContactType();
-//        }
-//
-//        @Override
-//        public boolean areContentsTheSame(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-//            return oldItem.equals(newItem);
-//        }
-//
-//        @Nullable
-//        @Override
-//        public Object getChangePayload(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-//            return newItem;
-//        }
-//    }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/FilterContactTypeAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/FilterContactTypeAdapter.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 
 import ru.yandex.practicum.contacts.databinding.ItemFilterBinding;
 import ru.yandex.practicum.contacts.model.ContactType;
+import ru.yandex.practicum.contacts.presentation.base.BaseListDiffCallback;
 import ru.yandex.practicum.contacts.presentation.filter.model.FilterContactType;
 import ru.yandex.practicum.contacts.presentation.filter.model.FilterContactTypeUi;
 import ru.yandex.practicum.contacts.utils.model.ContactTypeUtils;
@@ -26,7 +27,7 @@ public class FilterContactTypeAdapter extends RecyclerView.Adapter<FilterContact
 
     private final AsyncListDiffer<FilterContactTypeUi> differ = new AsyncListDiffer<>(
             new AdapterListUpdateCallback(this),
-            new AsyncDifferConfig.Builder<>(new ListDiffCallback()).build()
+            new AsyncDifferConfig.Builder<>(new BaseListDiffCallback()).build()
     );
 
     private final Consumer<FilterContactTypeUi> clickListener;
@@ -86,22 +87,22 @@ public class FilterContactTypeAdapter extends RecyclerView.Adapter<FilterContact
         }
     }
 
-    static class ListDiffCallback extends DiffUtil.ItemCallback<FilterContactTypeUi> {
-
-        @Override
-        public boolean areItemsTheSame(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-            return oldItem.getContactType() == newItem.getContactType();
-        }
-
-        @Override
-        public boolean areContentsTheSame(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-            return oldItem.equals(newItem);
-        }
-
-        @Nullable
-        @Override
-        public Object getChangePayload(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
-            return newItem;
-        }
-    }
+//    static class ListDiffCallback extends DiffUtil.ItemCallback<FilterContactTypeUi> {
+//
+//        @Override
+//        public boolean areItemsTheSame(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
+//            return oldItem.getContactType() == newItem.getContactType();
+//        }
+//
+//        @Override
+//        public boolean areContentsTheSame(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
+//            return oldItem.equals(newItem);
+//        }
+//
+//        @Nullable
+//        @Override
+//        public Object getChangePayload(@NonNull FilterContactTypeUi oldItem, @NonNull FilterContactTypeUi newItem) {
+//            return newItem;
+//        }
+//    }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/model/FilterContactTypeUi.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/filter/model/FilterContactTypeUi.java
@@ -2,7 +2,9 @@ package ru.yandex.practicum.contacts.presentation.filter.model;
 
 import androidx.annotation.NonNull;
 
-public class FilterContactTypeUi {
+import ru.yandex.practicum.contacts.presentation.base.ListDiffInterface;
+
+public class FilterContactTypeUi implements ListDiffInterface<FilterContactTypeUi> {
 
     private final FilterContactType contactType;
     private final boolean selected;
@@ -18,6 +20,11 @@ public class FilterContactTypeUi {
 
     public boolean isSelected() {
         return selected;
+    }
+
+    @Override
+    public boolean theSameAs(FilterContactTypeUi method) {
+        return this.getContactType() == method.getContactType();
     }
 
     @Override

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactAdapter.java
@@ -93,23 +93,4 @@ public class ContactAdapter extends RecyclerView.Adapter<ContactAdapter.ViewHold
                     .into(binding.contactPhoto);
         }
     }
-
-//    static class ListDiffCallback extends DiffUtil.ItemCallback<ContactUi> {
-//
-//        @Override
-//        public boolean areItemsTheSame(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-//            return oldItem.hashCode() == newItem.hashCode();
-//        }
-//
-//        @Override
-//        public boolean areContentsTheSame(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-//            return oldItem.equals(newItem);
-//        }
-//
-//        @Nullable
-//        @Override
-//        public Object getChangePayload(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-//            return newItem;
-//        }
-//    }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactAdapter.java
@@ -23,12 +23,13 @@ import java.util.Objects;
 
 import ru.yandex.practicum.contacts.R;
 import ru.yandex.practicum.contacts.databinding.ItemContactBinding;
+import ru.yandex.practicum.contacts.presentation.base.BaseListDiffCallback;
 
 public class ContactAdapter extends RecyclerView.Adapter<ContactAdapter.ViewHolder> {
 
     private final AsyncListDiffer<ContactUi> differ = new AsyncListDiffer<>(
             new AdapterListUpdateCallback(this),
-            new AsyncDifferConfig.Builder<>(new ListDiffCallback()).build()
+            new AsyncDifferConfig.Builder<>(new BaseListDiffCallback()).build()
     );
 
     @NonNull
@@ -93,22 +94,22 @@ public class ContactAdapter extends RecyclerView.Adapter<ContactAdapter.ViewHold
         }
     }
 
-    static class ListDiffCallback extends DiffUtil.ItemCallback<ContactUi> {
-
-        @Override
-        public boolean areItemsTheSame(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-            return oldItem.hashCode() == newItem.hashCode();
-        }
-
-        @Override
-        public boolean areContentsTheSame(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-            return oldItem.equals(newItem);
-        }
-
-        @Nullable
-        @Override
-        public Object getChangePayload(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
-            return newItem;
-        }
-    }
+//    static class ListDiffCallback extends DiffUtil.ItemCallback<ContactUi> {
+//
+//        @Override
+//        public boolean areItemsTheSame(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
+//            return oldItem.hashCode() == newItem.hashCode();
+//        }
+//
+//        @Override
+//        public boolean areContentsTheSame(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
+//            return oldItem.equals(newItem);
+//        }
+//
+//        @Nullable
+//        @Override
+//        public Object getChangePayload(@NonNull ContactUi oldItem, @NonNull ContactUi newItem) {
+//            return newItem;
+//        }
+//    }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactUi.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/main/ContactUi.java
@@ -5,8 +5,9 @@ import androidx.annotation.NonNull;
 import java.util.List;
 
 import ru.yandex.practicum.contacts.model.ContactType;
+import ru.yandex.practicum.contacts.presentation.base.ListDiffInterface;
 
-public class ContactUi {
+public class ContactUi implements ListDiffInterface<ContactUi> {
 
     private final String name;
     private final String phone;
@@ -39,6 +40,11 @@ public class ContactUi {
 
     public List<ContactType> getTypes() {
         return types;
+    }
+
+    @Override
+    public boolean theSameAs(ContactUi method) {
+        return this.hashCode() == method.hashCode();
     }
 
     @Override

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeAdapter.java
@@ -17,13 +17,14 @@ import java.util.function.Consumer;
 
 import ru.yandex.practicum.contacts.R;
 import ru.yandex.practicum.contacts.databinding.ItemSortBinding;
+import ru.yandex.practicum.contacts.presentation.base.BaseListDiffCallback;
 import ru.yandex.practicum.contacts.presentation.sort.model.SortType;
 
 public class SortTypeAdapter extends RecyclerView.Adapter<SortTypeAdapter.ViewHolder> {
 
     private final AsyncListDiffer<SortTypeUI> differ = new AsyncListDiffer<>(
             new AdapterListUpdateCallback(this),
-            new AsyncDifferConfig.Builder<>(new ListDiffCallback()).build()
+            new AsyncDifferConfig.Builder<>(new BaseListDiffCallback()).build()
     );
 
     private final Consumer<SortTypeUI> clickListener;
@@ -89,22 +90,22 @@ public class SortTypeAdapter extends RecyclerView.Adapter<SortTypeAdapter.ViewHo
         }
     }
 
-    static class ListDiffCallback extends DiffUtil.ItemCallback<SortTypeUI> {
-
-        @Override
-        public boolean areItemsTheSame(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-            return oldItem.getSortType() == newItem.getSortType();
-        }
-
-        @Override
-        public boolean areContentsTheSame(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-            return oldItem.equals(newItem);
-        }
-
-        @Nullable
-        @Override
-        public Object getChangePayload(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-            return newItem;
-        }
-    }
+//    static class ListDiffCallback extends DiffUtil.ItemCallback<SortTypeUI> {
+//
+//        @Override
+//        public boolean areItemsTheSame(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
+//            return oldItem.getSortType() == newItem.getSortType();
+//        }
+//
+//        @Override
+//        public boolean areContentsTheSame(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
+//            return oldItem.equals(newItem);
+//        }
+//
+//        @Nullable
+//        @Override
+//        public Object getChangePayload(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
+//            return newItem;
+//        }
+//    }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeAdapter.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeAdapter.java
@@ -89,23 +89,4 @@ public class SortTypeAdapter extends RecyclerView.Adapter<SortTypeAdapter.ViewHo
             }
         }
     }
-
-//    static class ListDiffCallback extends DiffUtil.ItemCallback<SortTypeUI> {
-//
-//        @Override
-//        public boolean areItemsTheSame(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-//            return oldItem.getSortType() == newItem.getSortType();
-//        }
-//
-//        @Override
-//        public boolean areContentsTheSame(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-//            return oldItem.equals(newItem);
-//        }
-//
-//        @Nullable
-//        @Override
-//        public Object getChangePayload(@NonNull SortTypeUI oldItem, @NonNull SortTypeUI newItem) {
-//            return newItem;
-//        }
-//    }
 }

--- a/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeUI.java
+++ b/app/src/main/java/ru/yandex/practicum/contacts/presentation/sort/SortTypeUI.java
@@ -2,9 +2,10 @@ package ru.yandex.practicum.contacts.presentation.sort;
 
 import androidx.annotation.NonNull;
 
+import ru.yandex.practicum.contacts.presentation.base.ListDiffInterface;
 import ru.yandex.practicum.contacts.presentation.sort.model.SortType;
 
-public class SortTypeUI {
+public class SortTypeUI implements ListDiffInterface<SortTypeUI> {
 
     private final SortType sortType;
     private final boolean selected;
@@ -20,6 +21,11 @@ public class SortTypeUI {
 
     public boolean isSelected() {
         return selected;
+    }
+
+    @Override
+    public boolean theSameAs(SortTypeUI method) {
+        return this.getSortType() == method.getSortType();
     }
 
     @Override


### PR DESCRIPTION
1. Создать интерфейс, который заставит классы, описывающие элементы списка, реализовывать методы для вычисления значения для метода areItemsTheSame() в методах с одинаковым названием.
2. Реализовать этот интерфейс в классах ContactUI, FilterContactTypeUI, SortTypeUI.
3. Создать дженерик-класс BaseListDiffCallback с ограничением параметра типа на обязательную реализацию интерфейса ListDiffInterface<>. Класс должен наследоваться  от DiffUtil.ItemCallback<>.
4. Заменить создание экземпляра класса при инициализации  объекта differ в каждом адаптере.
